### PR TITLE
Trying to solve repeated start/stop use events in short periods

### DIFF
--- a/conf/conf.hpp
+++ b/conf/conf.hpp
@@ -70,6 +70,9 @@ namespace fabomatic
     /// @brief Minimum time to confirm by long tap maintenance
     static constexpr auto LONG_TAP_DURATION{10s};
 
+    /// @brief Disabled RFID reading after a successfull read for X seconds.
+    static constexpr auto DELAY_BETWEEN_SWEEPS{2s};
+
   } // namespace conf::machine
 
   /// @brief Debug settings

--- a/include/BaseRfidWrapper.hpp
+++ b/include/BaseRfidWrapper.hpp
@@ -3,6 +3,7 @@
 #include <optional>
 
 #include "card.hpp"
+#include "Tasks.hpp"
 
 namespace fabomatic
 {
@@ -21,6 +22,8 @@ namespace fabomatic
     virtual auto readCardSerial() const -> std::optional<card::uid_t> = 0;
     virtual auto selfTest() const -> bool = 0;
     virtual auto reset() const -> void = 0;
+
+    virtual auto setDisabledUntil(fabomatic::Tasks::time_point t) -> void = 0;
   };
 } // namespace fabomatic
 #endif // BASERFIDWRAPPER_HPP_

--- a/include/BaseRfidWrapper.hpp
+++ b/include/BaseRfidWrapper.hpp
@@ -23,7 +23,7 @@ namespace fabomatic
     virtual auto selfTest() const -> bool = 0;
     virtual auto reset() const -> void = 0;
 
-    virtual auto setDisabledUntil(fabomatic::Tasks::time_point t) -> void = 0;
+    virtual auto setDisabledUntil(std::optional<Tasks::time_point> t) -> void = 0;
   };
 } // namespace fabomatic
 #endif // BASERFIDWRAPPER_HPP_

--- a/include/BoardLogic.hpp
+++ b/include/BoardLogic.hpp
@@ -95,7 +95,6 @@ namespace fabomatic
     FabBackend server;
     std::optional<std::reference_wrapper<BaseRFIDWrapper>> rfid{std::nullopt}; // Configured at runtime
     std::optional<std::reference_wrapper<LCDWrapper>> lcd{std::nullopt};       // Configured at runtime
-    bool ready_for_a_new_card{true};
     bool led_status{false};
 
     Machine machine;

--- a/include/RFIDWrapper.hpp
+++ b/include/RFIDWrapper.hpp
@@ -19,6 +19,7 @@ namespace fabomatic
   {
   private:
     std::unique_ptr<Driver> driver;
+    std::optional<fabomatic::Tasks::time_point> disabledUntil;
 
   public:
     RFIDWrapper();
@@ -46,6 +47,8 @@ namespace fabomatic
 
     [[nodiscard]] auto getUid() const -> card::uid_t override;
 
+    [[nodiscard]] auto setDisabledUntil(fabomatic::Tasks::time_point delay) -> void override;
+
     /// @brief Returns the driver object for testing/simulation
     Driver &getDriver();
 
@@ -53,7 +56,7 @@ namespace fabomatic
     RFIDWrapper &operator=(const RFIDWrapper &x) = delete; // copy assignment
     RFIDWrapper(RFIDWrapper &&) = delete;                  // move constructor
     RFIDWrapper &operator=(RFIDWrapper &&) = delete;       // move assignment
-    ~RFIDWrapper() override{};                             // Default destructor
+    ~RFIDWrapper() override {};                            // Default destructor
   };
 } // namespace fabomatic
 

--- a/include/RFIDWrapper.hpp
+++ b/include/RFIDWrapper.hpp
@@ -47,7 +47,7 @@ namespace fabomatic
 
     [[nodiscard]] auto getUid() const -> card::uid_t override;
 
-    [[nodiscard]] auto setDisabledUntil(fabomatic::Tasks::time_point delay) -> void override;
+    [[nodiscard]] auto setDisabledUntil(std::optional<Tasks::time_point> delay) -> void override;
 
     /// @brief Returns the driver object for testing/simulation
     Driver &getDriver();

--- a/platformio.ini
+++ b/platformio.ini
@@ -68,7 +68,6 @@ board_build.f_flash     = 80000000L
 build_flags             = ${env.build_flags}
                           -D ARDUINO_USB_CDC_ON_BOOT
 build_src_flags         = ${env.build_src_flags}
-                          -D CORE_DEBUG_LEVEL=5
                           -D MQTT_SIMULATION=false
                           -D RFID_SIMULATION=false
                           -D PINS_HARDWARE_REV0

--- a/src/BoardLogic.cpp
+++ b/src/BoardLogic.cpp
@@ -75,12 +75,6 @@ namespace fabomatic
   {
     ESP_LOGD(TAG, "New card present");
 
-    if (!ready_for_a_new_card)
-    {
-      return;
-    }
-    ready_for_a_new_card = false;
-
     if (machine.isFree())
     {
       // machine is free
@@ -556,13 +550,13 @@ namespace fabomatic
       const auto &result = rfid.readCardSerial();
       if (result)
       {
+        // This function may block for several seconds if a long tap is required
         onNewCard(result.value());
+        rfid.setDisabledUntil(Tasks::arduinoNow() + conf::machine::DELAY_BETWEEN_SWEEPS);
       }
       return;
     }
 
-    // No new card present
-    ready_for_a_new_card = true;
     if (machine.isFree())
     {
       changeStatus(Status::MachineFree);

--- a/src/RFIDWrapper.tpp
+++ b/src/RFIDWrapper.tpp
@@ -34,7 +34,7 @@ namespace fabomatic
   }
 
   template <typename Driver>
-  [[nodiscard]] auto RFIDWrapper<Driver>::setDisabledUntil(fabomatic::Tasks::time_point delay) -> void
+  [[nodiscard]] auto RFIDWrapper<Driver>::setDisabledUntil(std::optional<Tasks::time_point> delay) -> void
   {
     this->disabledUntil = delay;
   }

--- a/test/test_logic/test_common.cpp
+++ b/test/test_logic/test_common.cpp
@@ -21,7 +21,11 @@ namespace fabomatic::tests
                                         std::optional<std::chrono::milliseconds> duration_tap)
   {
     constexpr auto DEFAULT_CYCLES = 3;
+
+    // Ignore DELAY_BETWEEN_SWEEPS delay between cards events
+    rfid.setDisabledUntil(std::nullopt);
     MockMrfc522 &driver = rfid.getDriver();
+
     driver.resetUid();
     for (auto i = 0; i < DEFAULT_CYCLES; i++)
     {
@@ -38,7 +42,6 @@ namespace fabomatic::tests
         logic.checkRfid();
         delay(50);
       } while (duration_tap.has_value() && fabomatic::Tasks::arduinoNow() - start < duration_tap);
-
     }
     else if (duration_tap)
     {

--- a/test/test_logic/test_common.cpp
+++ b/test/test_logic/test_common.cpp
@@ -22,24 +22,26 @@ namespace fabomatic::tests
   {
     constexpr auto DEFAULT_CYCLES = 3;
 
-    // Ignore DELAY_BETWEEN_SWEEPS delay between cards events
-    rfid.setDisabledUntil(std::nullopt);
     MockMrfc522 &driver = rfid.getDriver();
 
     driver.resetUid();
+    rfid.setDisabledUntil(std::nullopt);
+
     for (auto i = 0; i < DEFAULT_CYCLES; i++)
     {
       logic.checkRfid();
+      rfid.setDisabledUntil(std::nullopt);
     }
+
     if (uid.has_value())
     {
       driver.setUid(uid.value(), duration_tap);
       TEST_ASSERT_TRUE_MESSAGE(uid == rfid.getUid(), "Card UID not equal");
       auto start = fabomatic::Tasks::arduinoNow();
-
       do
       {
         logic.checkRfid();
+        rfid.setDisabledUntil(std::nullopt);
         delay(50);
       } while (duration_tap.has_value() && fabomatic::Tasks::arduinoNow() - start < duration_tap);
     }

--- a/test/test_logic/test_logic.cpp
+++ b/test/test_logic/test_logic.cpp
@@ -141,6 +141,8 @@ namespace fabomatic::tests
     const auto card_uid = get_test_uid(1);
 
     simulate_rfid_card(rfid, logic, card_uid, std::nullopt);
+
+    Tasks::delay(fabomatic::conf::machine::DELAY_BETWEEN_SWEEPS);
     TEST_ASSERT_TRUE_MESSAGE(rfid.isNewCardPresent(), "New card not present");
     TEST_ASSERT_TRUE_MESSAGE(rfid.readCardSerial().has_value(), "Card serial not read");
     TEST_ASSERT_TRUE_MESSAGE(rfid.readCardSerial().value() == card_uid, "Card serial not equal");
@@ -271,8 +273,8 @@ namespace fabomatic::tests
     TEST_ASSERT_EQUAL_UINT16_MESSAGE(BoardLogic::Status::MaintenanceNeeded, logic.getStatus(), "Status not MaintenanceNeeded");
 
     simulate_rfid_card(rfid, logic, std::nullopt);
-    simulate_rfid_card(rfid, logic, card_admin, conf::machine::LONG_TAP_DURATION + 10s); // Log in + Conferma manutenzione perché non ritorna prima della conclusione
-    simulate_rfid_card(rfid, logic, std::nullopt);                                       // Card away
+    simulate_rfid_card(rfid, logic, card_admin, conf::machine::LONG_TAP_DURATION + 3s); // Log in + Conferma manutenzione perché non ritorna prima della conclusione
+    simulate_rfid_card(rfid, logic, std::nullopt);                                      // Card away
     TEST_ASSERT_EQUAL_UINT16_MESSAGE(BoardLogic::Status::MachineInUse, logic.getStatus(), "Status not MachineInUse by admin");
     TEST_ASSERT_FALSE_MESSAGE(logic.getMachine().isMaintenanceNeeded(), "Maintenance not cleared by admin");
 
@@ -355,7 +357,7 @@ void setup()
 {
   delay(1000);
   esp_log_level_set(TAG, LOG_LOCAL_LEVEL);
-  
+
   auto config = fabomatic::SavedConfig::LoadFromEEPROM();
   UNITY_BEGIN();
   RUN_TEST(fabomatic::tests::test_machine_defaults);


### PR DESCRIPTION
Probably the user is keeping the card a little bit too long on the box, so I added a configuration settings with 2s default value to disable RFID readings.