### PR TITLE
Improve board responsiveness when MQTT broker is up but backend is down.

### DIFF
--- a/conf/conf.hpp
+++ b/conf/conf.hpp
@@ -148,10 +148,13 @@ namespace fabomatic
     static constexpr std::string_view request_topic{"/request"};
 
     /// @brief Number of tries to get a reply from the backend
-    static constexpr auto MAX_TRIES{2};
+    static constexpr auto MAX_TRIES{1};
 
     /// @brief Timeout for a single backend reply request.
     static constexpr auto TIMEOUT_REPLY_SERVER{2s};
+
+    /// @brief Once backend is unresponsive, wait at least this period before to try again
+    static constexpr auto FAIL_FAST_PERIOD {45s};
 
     /// @brief MQTT port for broker
     static constexpr auto PORT_NUMBER{1883};

--- a/include/BoardInfo.hpp
+++ b/include/BoardInfo.hpp
@@ -8,15 +8,17 @@ namespace fabomatic
   /// @brief Helper struct representing the display state
   struct BoardInfo
   {
-    bool server_connected;
-    Machine::PowerState power_state;
-    bool power_warning;
+    bool mqtt_connected{false};
+    Machine::PowerState power_state{Machine::PowerState::Unknown};
+    bool power_warning{false};
+    bool unresponsive{true};
 
     [[nodiscard]] auto operator==(const BoardInfo &other) const -> bool
     {
-      return server_connected == other.server_connected &&
+      return mqtt_connected == other.mqtt_connected &&
              power_state == other.power_state &&
-             power_warning == other.power_warning;
+             power_warning == other.power_warning &&
+             unresponsive == other.unresponsive;
     };
   };
 } // namespace fabomatic

--- a/include/FabBackend.hpp
+++ b/include/FabBackend.hpp
@@ -89,6 +89,7 @@ namespace fabomatic
     [[nodiscard]] auto hasBufferedMsg() const -> bool;
     [[nodiscard]] auto transmitBuffer() -> bool;
     [[nodiscard]] auto saveBuffer() -> bool;
+    [[nodiscard]] auto shouldFailFast() const -> bool;
 
     [[nodiscard]] auto checkBackendRequest() -> std::optional<std::unique_ptr<MQTTInterface::BackendRequest>>;
 

--- a/include/FabBackend.hpp
+++ b/include/FabBackend.hpp
@@ -50,14 +50,14 @@ namespace fabomatic
     std::string last_reply{""};
     std::string last_request{""};
 
-    bool online{false};
+    bool mqtt_connected{false};
     bool answer_pending{false};
     int16_t channel{-1};
 
     Buffer buffer;
+    std::optional<Tasks::time_point> last_unresponsive{std::nullopt};
 
     auto messageReceived(String &topic, String &payload) -> void;
-    auto requestReceived(String &topic, String &payload) -> void;
 
     template <typename QueryT>
     [[nodiscard]] auto publish(const QueryT &payload) -> PublishResult;
@@ -85,6 +85,7 @@ namespace fabomatic
     [[nodiscard]] auto alive() -> bool;
     [[nodiscard]] auto publish(String topic, String payload, bool waitForAnswer) -> bool;
     [[nodiscard]] auto isOnline() const -> bool;
+    [[nodiscard]] auto isResponsive() const -> bool;
     [[nodiscard]] auto hasBufferedMsg() const -> bool;
     [[nodiscard]] auto transmitBuffer() -> bool;
     [[nodiscard]] auto saveBuffer() -> bool;

--- a/include/mock/MockMQTTBroker.hpp
+++ b/include/mock/MockMQTTBroker.hpp
@@ -29,6 +29,7 @@ namespace fabomatic
     auto processQueries() -> size_t;
 
     auto mainLoop() -> void;
+    auto generateReplies(bool enabled) -> void;
 
   private:
     std::mutex mutex;
@@ -46,6 +47,7 @@ namespace fabomatic
     { return defaultReplies(query); };
 
     bool is_running{false};
+    bool generate_replies{true};
   };
 } // namespace fabomatic
 #endif // MOCK_MOCKMQTTBROKER_HPP_

--- a/src/AuthProvider.cpp
+++ b/src/AuthProvider.cpp
@@ -60,7 +60,12 @@ namespace fabomatic
     ESP_LOGD(TAG, "tryLogin called for %s", uid_str.c_str());
 
     if (!server.isOnline())
-      server.connect();
+    {
+      if (!server.shouldFailFast())
+      {
+        server.connect();
+      }
+    }
 
     if (server.isOnline())
     {

--- a/src/BoardLogic.cpp
+++ b/src/BoardLogic.cpp
@@ -122,7 +122,7 @@ namespace fabomatic
   {
     constexpr auto STEPS_COUNT = 6;
     constexpr milliseconds delay_per_step = std::chrono::duration_cast<std::chrono::milliseconds>(conf::machine::LONG_TAP_DURATION) / STEPS_COUNT;
-    const BoardInfo bi = {server.isOnline(), machine.getPowerState(), machine.isShutdownImminent()};
+    const BoardInfo bi = {server.isOnline(), machine.getPowerState(), machine.isShutdownImminent(), !server.isResponsive()};
 
     for (auto step = 0; step < STEPS_COUNT; step++)
     {
@@ -425,7 +425,7 @@ namespace fabomatic
       lcd.setRow(1, buffer.str());
       break;
     }
-    BoardInfo bi = {server.isOnline(), machine.getPowerState(), machine.isShutdownImminent()};
+    BoardInfo bi = {server.isOnline(), machine.getPowerState(), machine.isShutdownImminent(), !server.isResponsive()};
     lcd.update(bi, false);
   }
 

--- a/src/FabBackend.cpp
+++ b/src/FabBackend.cpp
@@ -225,7 +225,7 @@ namespace fabomatic
       }
     } while (Tasks::arduinoNow() < (start_time + max_duration));
 
-    ESP_LOGE(TAG, "Failure, no answer from MQTT server (timeout:%lld ms)", max_duration.count());
+    ESP_LOGE(TAG, "Failure, no answer from MQTT server (timeout:%" PRId64 " ms)", max_duration.count());
 
     return false;
   }

--- a/src/FabBackend.cpp
+++ b/src/FabBackend.cpp
@@ -32,7 +32,7 @@ namespace fabomatic
 #else
     channel = -1;
 #endif
-    online = false;
+    mqtt_connected = false;
 
     std::stringstream ss_topic_name, ss_client_name;
     ss_topic_name << conf::mqtt::topic << "/" << config.machine_id;
@@ -83,6 +83,7 @@ namespace fabomatic
       if (waitForAnswer(conf::mqtt::TIMEOUT_REPLY_SERVER))
       {
         ESP_LOGD(TAG, "MQTT Client: received answer: %s", last_reply.data());
+        last_unresponsive = std::nullopt;
         return PublishResult::PublishedWithAnswer;
       }
 
@@ -101,6 +102,7 @@ namespace fabomatic
 
     if (published)
     {
+      last_unresponsive = Tasks::arduinoNow();
       return PublishResult::PublishedWithoutAnswer;
     }
 
@@ -112,10 +114,10 @@ namespace fabomatic
    *
    * @param mqtt_topic The topic to publish to.
    * @param mqtt_payload The payload to publish.
-   * @param waitForAnswer Whether to wait for an answer.
+   * @param answerNeeded Whether to wait for an answer.
    * @return true if the message was published successfully, false otherwise.
    */
-  bool FabBackend::publish(String mqtt_topic, String mqtt_payload, bool waitForAnswer)
+  bool FabBackend::publish(String mqtt_topic, String mqtt_payload, bool answerNeeded)
   {
     if (mqtt_payload.length() + mqtt_topic.length() > FabBackend::MAX_MSG_SIZE - 8)
     {
@@ -123,7 +125,7 @@ namespace fabomatic
       return false;
     }
 
-    answer_pending = waitForAnswer;
+    answer_pending = answerNeeded;
     last_query.assign(mqtt_payload.c_str());
 
     ESP_LOGI(TAG, "MQTT Client: sending message %s on topic %s", mqtt_payload.c_str(), mqtt_topic.c_str());
@@ -185,11 +187,11 @@ namespace fabomatic
   {
     if (!client.loop())
     {
-      if (online)
+      if (mqtt_connected)
       {
         ESP_LOGI(TAG, "MQTT Client: connection lost");
       }
-      online = false;
+      mqtt_connected = false;
       return false;
     }
     return true;
@@ -224,17 +226,28 @@ namespace fabomatic
     } while (Tasks::arduinoNow() < (start_time + max_duration));
 
     ESP_LOGE(TAG, "Failure, no answer from MQTT server (timeout:%lld ms)", max_duration.count());
+
     return false;
   }
 
   /**
-   * @brief Checks if the client is online.
+   * @brief Indicates if the MQTT client is connected to the broker and backend is responsive.
    *
    * @return true if the client is online, false otherwise.
    */
   bool FabBackend::isOnline() const
   {
-    return online;
+    return mqtt_connected && isResponsive();
+  }
+
+  /**
+   * @brief Indicates if backend answers are received
+   *
+   * @return true if the backend is responding, false otherwise.
+   */
+  bool FabBackend::isResponsive() const
+  {
+    return !last_unresponsive;
   }
 
   /**
@@ -310,7 +323,7 @@ namespace fabomatic
     // Check if WiFi network is available, and if not, try to connect
     if (status != WL_CONNECTED)
     {
-      online = false;
+      mqtt_connected = false;
 
       if (client.connected())
       {
@@ -367,7 +380,7 @@ namespace fabomatic
         else
         {
           ESP_LOGD(TAG, "MQTT Client: subscribed to reply topic %s", response_topic.c_str());
-          online = true;
+          mqtt_connected = true;
         }
 
         std::stringstream ss_req{};
@@ -381,7 +394,7 @@ namespace fabomatic
         else
         {
           ESP_LOGD(TAG, "MQTT Client: subscribed to requests topic %s", request_topic.c_str());
-          online = true;
+          mqtt_connected = true;
         }
 
         // Announce the board to the server
@@ -402,10 +415,15 @@ namespace fabomatic
 
     if (!client.connected())
     {
-      online = false;
+      mqtt_connected = false;
+      last_unresponsive = Tasks::arduinoNow();
+    }
+    else
+    {
+      last_unresponsive = std::nullopt;
     }
 
-    return online;
+    return mqtt_connected;
   }
 
   /**

--- a/src/LCDWrapper.cpp
+++ b/src/LCDWrapper.cpp
@@ -85,7 +85,18 @@ namespace fabomatic
     {
       lcd.setCursor(conf::lcd::COLS - 2, 0);
       lcd.write(CHAR_ANTENNA);
-      lcd.write(info.server_connected ? CHAR_CONNECTION : CHAR_NO_CONNECTION);
+      if (info.mqtt_connected)
+      {
+        lcd.write(CHAR_CONNECTION);
+      }
+      else if (info.unresponsive)
+      {
+        lcd.write('?');
+      }
+      else
+      {
+        lcd.write(CHAR_NO_CONNECTION);
+      }
     }
 
     if (show_power_status)
@@ -183,7 +194,18 @@ namespace fabomatic
     // Add symbols
     constexpr auto symbols_per_line = conf::lcd::COLS + 3;
 
-    str[symbols_per_line * 2 - 2] = bi.server_connected ? 'Y' : 'x';
+    if (bi.mqtt_connected)
+    {
+      str[symbols_per_line * 2 - 2] = 'Y';
+    }
+    else if (bi.unresponsive)
+    {
+      str[symbols_per_line * 2 - 2] = '?';
+    }
+    else
+    {
+      str[symbols_per_line * 2 - 2] = 'x';
+    }
 
     if (bi.power_state == Machine::PowerState::PoweredOn)
       str[symbols_per_line * 3 - 1] = 'Y';

--- a/src/Machine.cpp
+++ b/src/Machine.cpp
@@ -101,7 +101,7 @@ namespace fabomatic
         power(false);
       }
 
-      ESP_LOGI(TAG, "Machine will be shutdown in %lld s",
+      ESP_LOGI(TAG, "Machine will be shutdown in %" PRId64 " s",
                config.value().grace_period.count());
     }
   }
@@ -282,7 +282,7 @@ namespace fabomatic
 
     if (config.value().autologoff != new_delay)
     {
-      ESP_LOGD(TAG, "Changing autologoff delay to %lld min",
+      ESP_LOGD(TAG, "Changing autologoff delay to %" PRId64 " min",
                std::chrono::duration_cast<std::chrono::minutes>(config.value().autologoff).count());
     }
 
@@ -359,7 +359,7 @@ namespace fabomatic
 
     if (config.value().grace_period != new_delay)
     {
-      ESP_LOGD(TAG, "Changing grace period to %lld seconds",
+      ESP_LOGD(TAG, "Changing grace period to %" PRId64 " seconds",
                new_delay.count());
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,11 @@ namespace fabomatic
       Board::logic.changeStatus(Status::Connecting);
 
       // Try to connect
-      server.connect();
+      if (!server.shouldFailFast())
+      {
+        server.connect();
+      }
+
       // Refresh after connection
       Board::logic.changeStatus(server.isOnline() ? Status::Connected : Status::Offline);
 

--- a/src/mock/MockMQTTBroker.cpp
+++ b/src/mock/MockMQTTBroker.cpp
@@ -223,7 +223,7 @@ namespace fabomatic
       queries.pop();
       response = callback(topic, query);
 
-      if (!response.empty())
+      if (!response.empty() && generate_replies)
       {
         ESP_LOGI(TAG2, "MQTT BROKER: Sending %s -> %s", reply_topic.c_str(), response.c_str());
         publish(reply_topic, response);
@@ -250,6 +250,15 @@ namespace fabomatic
       update();
       processQueries();
     }
+  }
+
+  /**
+   * @brief Enable or disable reply generation by mockup
+   */
+  auto MockMQTTBroker::generateReplies(bool enabled) -> void
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    generate_replies = enabled;
   }
 } // namespace fabomatic
 

--- a/test/test_mqtt/test_mqtt.cpp
+++ b/test/test_mqtt/test_mqtt.cpp
@@ -384,7 +384,11 @@ namespace fabomatic::tests
       logic.changeStatus(BoardLogic::Status::Connecting);
 
       // Try to connect
-      server.connect();
+      if (!server.shouldFailFast())
+      {
+        server.connect();
+      }
+
       // Refresh after connection
       logic.changeStatus(server.isOnline() ? BoardLogic::Status::Connected : BoardLogic::Status::Offline);
     }

--- a/test/test_mqtt/test_mqtt.cpp
+++ b/test/test_mqtt/test_mqtt.cpp
@@ -39,7 +39,7 @@ namespace fabomatic::tests
 
   void busyWait(std::chrono::seconds d = 3s)
   {
-    auto start = fabomatic::Tasks::arduinoNow();
+    const auto start = fabomatic::Tasks::arduinoNow();
     while (fabomatic::Tasks::arduinoNow() - start <= d)
     {
       test_scheduler.execute();
@@ -366,6 +366,8 @@ namespace fabomatic::tests
 
     // Renable backend
     broker.generateReplies(true);
+
+    TEST_ASSERT_TRUE_MESSAGE(server.connect(), "(degraded) force reconnection");
 
     auto alive_resp = server.alive();
     TEST_ASSERT_TRUE_MESSAGE(alive_resp, "(degraded) Server alive failed");

--- a/test/test_mqtt/test_mqtt.cpp
+++ b/test/test_mqtt/test_mqtt.cpp
@@ -364,6 +364,7 @@ namespace fabomatic::tests
     if (server.isOnline())
     {
       TEST_ASSERT_TRUE_MESSAGE(server.loop(), "test_taskMQTTAlive: Server loop failed");
+      TEST_ASSERT_TRUE_MESSAGE(server.isResponsive(), "Server is not returning answers!");
     }
   }
 


### PR DESCRIPTION
This is probably a corner case, configuration error on the backend side, but it makes the board almost unusable.